### PR TITLE
Bump arweave.js version

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
         "test": "mocha --timeout 10000"
     },
     "dependencies": {
-        "arweave": "^1.5.3",
+        "arweave": "^1.9.1",
         "body-parser": "^1.19.0",
         "dotenv": "^8.2.0",
         "express": "^4.17.1",


### PR DESCRIPTION
Some Gifs were not properly uploaded to Arweave. Bumping the version of arweave js should solve this.