### PR TITLE
FIX: Content-Type tag not being set for arweave transaction

### DIFF
--- a/api/permapin.js
+++ b/api/permapin.js
@@ -40,7 +40,7 @@ module.exports = async (req, res) => {
                 );
             }
 
-            const type = fromBuffer(data);
+            const type = await fromBuffer(data);
 
             let tags = {
                 'IPFS-Add': ipfsHash,


### PR DESCRIPTION
Await file-type's `fromBuffer()` returned Promise

https://github.com/sindresorhus/file-type/blob/6ab25f3f6e3be0cbb09c800f7a79fb71ecfbc2db/core.d.ts#L303